### PR TITLE
Add 'go mod init' to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /wolweb
 RUN apk update && apk upgrade && \
     apk add --no-cache git && \
     git clone https://github.com/sameerdhoot/wolweb . && \
+    go mod init wolweb && \
     go get -d github.com/gorilla/handlers && \
     go get -d github.com/gorilla/mux && \
     go get -d github.com/ilyakaznacheev/cleanenv


### PR DESCRIPTION
Add 'go mod init' command in order for docker build command to succeed on a fresh pull