### PR TITLE
Configure github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,77 @@
----
-name: Release
+name: Build Docker Containers
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+      - ".gitignore"
+  workflow_dispatch:
 
 jobs:
-  release:
+  build-alpine:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Build and publish the container image for ${{ github.repository }}:${{ github.ref_name }}
-        uses: macbre/push-to-ghcr@v9
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
         with:
-          image_name: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: Dockerfile
-          image_tag:  ${{ github.ref_name }}
-      - name: Build and publish the container image for ${{ github.repository }}:latest
-        uses: macbre/push-to-ghcr@v9
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Alpine Dockerfile
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
         with:
-          image_name: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: Dockerfile
-          image_tag: latest
+          platforms: linux/arm64,linux/armhf,linux/386,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:alpine
+          pull: false
+          context: .
+          file: Dockerfile
+
+  build-debian:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Debian Dockerfile
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          platforms: linux/arm64,linux/armhf,linux/386,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:debian
+          pull: false
+          context: .
+          file: Debian_Dockerfile

--- a/Debian_Dockerfile
+++ b/Debian_Dockerfile
@@ -38,4 +38,4 @@ CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
 HEALTHCHECK --interval=5s --timeout=3s \
-  CMD curl -sf http://localhost:${WOLWEBPORT}/wolweb/health || exit 1
+  CMD curl --silent --show-error --fail http://localhost:${WOLWEBPORT}/wolweb/health || exit 1

--- a/Debian_Dockerfile
+++ b/Debian_Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /wolweb
 
 # Install Dependecies
 RUN git clone https://github.com/sameerdhoot/wolweb . && \
+    go mod init wolweb && \
     go get -d github.com/gorilla/handlers && \
     go get -d github.com/gorilla/mux && \
     go get -d github.com/ilyakaznacheev/cleanenv

--- a/Debian_Dockerfile
+++ b/Debian_Dockerfile
@@ -38,4 +38,4 @@ CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
 HEALTHCHECK --interval=5s --timeout=3s \
-  CMD curl -f http://localhost:${WOLWEBPORT}/wolweb || exit 1
+  CMD curl -sf http://localhost:${WOLWEBPORT}/wolweb/health || exit 1

--- a/Debian_Dockerfile
+++ b/Debian_Dockerfile
@@ -26,8 +26,16 @@ COPY --from=builder /wolweb/devices.json .
 COPY --from=builder /wolweb/config.json .
 COPY --from=builder /wolweb/static ./static
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && apt-get install -y \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+
 ARG WOLWEBPORT=8089
+ENV WOLWEBPORT=${WOLWEBPORT}
 
 CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
+HEALTHCHECK --interval=5s --timeout=3s \
+  CMD curl -f http://localhost:${WOLWEBPORT}/wolweb || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
 HEALTHCHECK --interval=5s --timeout=3s \
-  CMD curl -sf http://localhost:${WOLWEBPORT}/wolweb/health || exit 1
+  CMD curl --silent --show-error --fail http://localhost:${WOLWEBPORT}/wolweb/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
 HEALTHCHECK --interval=5s --timeout=3s \
-  CMD curl -f http://localhost:${WOLWEBPORT}/wolweb || exit 1
+  CMD curl -sf http://localhost:${WOLWEBPORT}/wolweb/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,13 @@ COPY --from=builder /wolweb/devices.json .
 COPY --from=builder /wolweb/config.json .
 COPY --from=builder /wolweb/static ./static
 
+RUN apk add --no-cache curl
+
 ARG WOLWEBPORT=8089
+ENV WOLWEBPORT=${WOLWEBPORT}
 
 CMD ["/wolweb/wolweb"]
 
 EXPOSE ${WOLWEBPORT}
+HEALTHCHECK --interval=5s --timeout=3s \
+  CMD curl -f http://localhost:${WOLWEBPORT}/wolweb || exit 1


### PR DESCRIPTION
This PR configures a GitHub workflow to build both Debian and Alpine containers, It also fixes the build process for the Debian container.

Tags:
- Debian container is tagged as `:debian`
- Alpine container is tagged with both `:alpine` and `:latest`

Build process is automatically started on commit to main excluding the readme, license, and .gitignore files, though it can also be manually started.