### PR TITLE
Fix saving devices.json with custom path.

### DIFF
--- a/data.go
+++ b/data.go
@@ -34,7 +34,7 @@ func saveData(w http.ResponseWriter, r *http.Request) {
 	var result HTTPResponseObject
 
 	log.Printf("New Application data received for saving to disk")
-	file, fileErr := os.OpenFile("devices.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	file, fileErr := os.OpenFile(args.DevicesPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	decoderErr := json.NewDecoder(r.Body).Decode(&appData)
 
 	baseErrStr := "Unable to save data to disk. "

--- a/main.go
+++ b/main.go
@@ -145,6 +145,9 @@ func processArgs() {
 		log.Fatal(err)
 	}
 
+	log.Printf("configuration file path: %s", configPath)
+	log.Printf("devices file path: %s", configPath)
+
 	args.ConfigPath = configPath
 	args.DevicesPath = devicesPath
 }


### PR DESCRIPTION
When saving, the used `devices.json` file path was not the configured path. Also prints final configured paths to make it easier to know what the program is actually using.